### PR TITLE
Add user subscription check for tags via new API endpoint

### DIFF
--- a/services/TagService/src/TagService.Api/Controllers/TagServiceController.cs
+++ b/services/TagService/src/TagService.Api/Controllers/TagServiceController.cs
@@ -21,6 +21,7 @@ using TagService.Application.Features.Tags.GetTagByName;
 using TagService.Application.Features.Tags.GetTags;
 using TagService.Application.Features.Tags.UpdateTag;
 using TagService.Application.Features.Tags.UpdateTagCountQuestion;
+using TagService.Application.Features.WatchedTags.CheckUserSubscription;
 using TagService.Application.Features.WatchedTags.CreateWatchedTag;
 using TagService.Application.Features.WatchedTags.DeleteWatchedTag;
 using TagService.Application.Features.WatchedTags.GetUserWatchedTags;
@@ -54,6 +55,17 @@ public class TagServiceController : ControllerBase{
         [FromServices] ICommandHandler<TagDTO, GetTagByNameCommand> handler ) =>
         await handler.Handle(new GetTagByNameCommand(tagName), new CancellationToken(false));
 
+    [HttpGet ("watched/{userId}/{tagId}/check")]
+    [SwaggerOperation (Summary = "Проверить подписку пользователя на тэг."
+        , Description = "Возвращает true, если пользователь подписан на указанный тэг, иначе false."
+        , OperationId = "Tag_CheckSubscription")]
+    public async Task<Result<CheckUserSubcriptionResponse>> CheckUserSubscriptionAsync (
+        Guid userId
+        , int tagId
+        , [FromServices] ICommandHandler<CheckUserSubcriptionResponse, CheckUserSubscriptionCommand> handler) {
+        return await handler.Handle (new CheckUserSubscriptionCommand (userId, tagId), new CancellationToken (false));
+    }
+    
     [HttpGet]
     [SwaggerOperation(
     Summary = "Получить список тэгов.",

--- a/services/TagService/src/TagService.Application/Features/WatchedTags/CheckUserSubscription/CheckUserSubscriptionCommand.cs
+++ b/services/TagService/src/TagService.Application/Features/WatchedTags/CheckUserSubscription/CheckUserSubscriptionCommand.cs
@@ -1,0 +1,5 @@
+using Abstractions.Commands;
+
+namespace TagService.Application.Features.WatchedTags.CheckUserSubscription;
+
+public record CheckUserSubscriptionCommand (Guid UserId, int TagId) : ICommand;

--- a/services/TagService/src/TagService.Application/Features/WatchedTags/CheckUserSubscription/CheckUserSubscriptionHandler.cs
+++ b/services/TagService/src/TagService.Application/Features/WatchedTags/CheckUserSubscription/CheckUserSubscriptionHandler.cs
@@ -1,0 +1,30 @@
+using Abstractions.Commands;
+
+using Ardalis.Result;
+
+using Contracts.Responses.TagService;
+
+using TagService.Domain.Repositories;
+
+namespace TagService.Application.Features.WatchedTags.CheckUserSubscription;
+
+public class
+  CheckUserSubscriptionHandler : ICommandHandler<CheckUserSubcriptionResponse, CheckUserSubscriptionCommand> {
+
+  private readonly IWatchedTagRepository _watchedTagRepository;
+
+  public CheckUserSubscriptionHandler (IWatchedTagRepository watchedTagRepository) {
+    _watchedTagRepository = watchedTagRepository;
+  }
+
+  public async Task<Result<CheckUserSubcriptionResponse>> Handle (
+    CheckUserSubscriptionCommand command
+    , CancellationToken cancellationToken) {
+    var result = await _watchedTagRepository.ExistsAsync (command.UserId, command.TagId, cancellationToken);
+
+    return result
+      ? Result.Success (new CheckUserSubcriptionResponse (true))
+      : Result.Success (new CheckUserSubcriptionResponse (false));
+  }
+
+}

--- a/shared/src/Contracts/Responses/TagService/CheckUserSubcriptionResponse.cs
+++ b/shared/src/Contracts/Responses/TagService/CheckUserSubcriptionResponse.cs
@@ -1,0 +1,3 @@
+namespace Contracts.Responses.TagService;
+
+public record CheckUserSubcriptionResponse (bool IsSubscribed);


### PR DESCRIPTION
Expanded functionality to include a check for user subscriptions to tags using a new API endpoint. This ensures features relying on tag subscriptions are accurate and up-to-date.